### PR TITLE
timeoutQueue check / dport in key hashing

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -169,7 +169,7 @@ func LZRMain() {
 	incomingDone.Wait()
 
     for {
-       if done && len(writingQueue) == 0 && !writing {
+       if done && len(writingQueue) == 0 && !writing && len(timeoutQueue) == 0 {
 				if options.MemProfile != "" {
 					f, err := os.Create(options.MemProfile)
 					if err != nil {

--- a/stateMap.go
+++ b/stateMap.go
@@ -32,7 +32,7 @@ func ConstructPacketStateMap( opts *options ) pState {
 
 
 func constructKey( packet *packet_metadata ) string {
-	return packet.Saddr + ":" + strconv.Itoa(packet.Sport)
+	return packet.Saddr + ":" + strconv.Itoa(packet.Sport) + ":" + strconv.Itoa(packet.Dport)
 }
 
 func constructParentKey( packet *packet_metadata, parentSport int ) string {


### PR DESCRIPTION
Included check for length of timeoutQueue in bin.go before completing run. 
Included packet destination port in key construction in stateMap.go to account for repeat sends to the same IP. 