### PR TITLE
Fix: Premature process termination

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -1,8 +1,8 @@
 package bin
 
 import (
-    "time"
-    //"context"
+	"time"
+	//"context"
 	"fmt"
 	"log"
 	"os"
@@ -12,17 +12,16 @@ import (
 	"github.com/stanford-esrg/lzr"
 )
 
-
 func LZRMain() {
-    // create a context that can be cancelled
-    //ctx, cancel := context.WithCancel(context.Background())
+	// create a context that can be cancelled
+	//ctx, cancel := context.WithCancel(context.Background())
 
 	start := time.Now()
 
-    //read in config
-    options, ok := lzr.Parse()
+	//read in config
+	options, ok := lzr.Parse()
 	if !ok {
-		fmt.Fprintln(os.Stderr,"Failed to parse command line options, exiting.")
+		fmt.Fprintln(os.Stderr, "Failed to parse command line options, exiting.")
 		return
 	}
 
@@ -30,80 +29,84 @@ func LZRMain() {
 	if options.CPUProfile != "" {
 		f, err := os.Create(options.CPUProfile)
 		if err != nil {
-            log.Fatal(err)
-        }
-        pprof.StartCPUProfile(f)
-        defer pprof.StopCPUProfile()
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
 	}
 
 	//initalize
-	ipMeta := lzr.ConstructPacketStateMap( options )
-    f := lzr.InitFile( options.Filename )
+	ipMeta := lzr.ConstructPacketStateMap(options)
+	f := lzr.InitFile(options.Filename)
 	lzr.InitParams()
 
-    writingQueue := lzr.ConstructWritingQueue( options.Workers )
-    pcapIncoming := lzr.ConstructPcapRoutine( options.Workers )
-	timeoutQueue := lzr.ConstructTimeoutQueue( options.Workers )
-    retransmitQueue := lzr.ConstructRetransmitQueue( options.Workers )
-    timeoutIncoming := lzr.PollTimeoutRoutine(
-        &ipMeta,timeoutQueue, retransmitQueue, options.Workers, options.Timeout, options.RetransmitSec )
-	incoming := lzr.ConstructIncomingRoutine( options.Workers )
+	writingQueue := lzr.ConstructWritingQueue(options.Workers)
+	pcapIncoming := lzr.ConstructPcapRoutine(options.Workers)
+	timeoutQueue := lzr.ConstructTimeoutQueue(options.Workers)
+	retransmitQueue := lzr.ConstructRetransmitQueue(options.Workers)
+	timeoutIncoming := lzr.PollTimeoutRoutine(
+		&ipMeta, timeoutQueue, retransmitQueue, options.Workers, options.Timeout, options.RetransmitSec)
+	incoming := lzr.ConstructIncomingRoutine(options.Workers)
 	var incomingDone sync.WaitGroup
 	incomingDone.Add(options.Workers)
-    done := false
+	done := false
 	writing := false
-	timeoutDone := true
 
-    // record to file
-    go func() {
-        for {
-            select {
-                case input := <-writingQueue:
-					writing = true
-                    f.Record( input, options.Handshakes )
-					writing = false
-                }
-        }
-    }()
-    //start all workers
+	// record to file
+	go func() {
+		for {
+			select {
+			case input := <-writingQueue:
+				writing = true
+				f.Record(input, options.Handshakes)
+				writing = false
+			}
+		}
+	}()
+	//start all workers
 
-    //read from zmap
-
-	for i := 0; i < options.Workers; i ++ {
-        go func( i int ) {
-            //ExitCondition: incoming channel closed
-			if (i == options.Workers - 1) {
+	//read from zmap
+	var wgForHandshakeComplete = new(sync.WaitGroup)
+	wgForHandshakeComplete.Add(1)
+	for i := 0; i < options.Workers; i++ {
+		go func(i int) {
+			//ExitCondition: incoming channel closed
+			if i == options.Workers-1 {
 				// a band-aid has been added to check to see if the number of items
 				// in ipMeta has stayed the same for numHandshakes * timeout*2 time
 				// if so, close. there is some non-deterministic
 				// infinite loop condition that needs to be fixed in which ipMeta
 				// does not empty all the way
 				var infiniteLoop = false
-				var ipMetaSize = ipMeta.Count()
-				var intervalLoop = options.Timeout*lzr.NumHandshakes()*2
+				var lastIpMetaSize = ipMeta.Count()
+				var intervalLoop = options.Timeout * lzr.NumHandshakes() * 2
 				go func() {
+					defer wgForHandshakeComplete.Done()
 					for {
 						startTime := time.Now()
-			                        for time.Since(startTime) < time.Duration(intervalLoop)*time.Second {
-			                            if (ipMeta.HasUpdates()) {
-			                                startTime = time.Now()
-			                                ipMeta.ResetUpdates()
-			                                continue
-			                            }
-			                            time.Sleep(time.Duration(intervalLoop)*time.Millisecond)
-			                        }
-						if (ipMetaSize == ipMeta.Count()) {
-							fmt.Fprintln(os.Stderr,"Infinite Loop, Breaking.")
+						for time.Since(startTime) < time.Duration(intervalLoop)*time.Second {
+							if ipMeta.HasUpdates() {
+								startTime = time.Now()
+								ipMeta.ResetUpdates()
+								continue
+							}
+							time.Sleep(time.Duration(intervalLoop) * time.Millisecond)
+						}
+						ipMetaSize, isIpMetaChanged := ipMeta.CountAndHasUpdates()
+						if lastIpMetaSize == ipMetaSize && !isIpMetaChanged {
+							fmt.Fprintln(os.Stderr, "Infinite Loop, Breaking.")
 							infiniteLoop = true
 							return
+						} else if ipMetaSize == 0 && isIpMetaChanged {
+							fmt.Fprintln(os.Stderr, "Everything has been processed, Breaking.")
 						} else {
-							ipMetaSize = ipMeta.Count()
+							lastIpMetaSize = ipMeta.Count()
 						}
 					}
 				}()
 				for {
 					if ipMeta.IsEmpty() /*|| infiniteLoop*/ {
-						done=true
+						done = true
 						break
 					}
 					if infiniteLoop {
@@ -111,108 +114,101 @@ func LZRMain() {
 						break
 					}
 					//slow down to prevent CPU busy looping
-					time.Sleep(1*time.Second)
-					fmt.Fprintln(os.Stderr,"Processing:", ipMeta.Count())
+					time.Sleep(1 * time.Second)
+					fmt.Fprintln(os.Stderr, "Processing:", ipMeta.Count())
 				}
 			}
 
-	        for input := range incoming {
+			for input := range incoming {
 				if lzr.ReadZMap() {
 					toACK := true
 					toPUSH := false
-					lzr.SendAck( options, input, &ipMeta, timeoutQueue,
+					lzr.SendAck(options, input, &ipMeta, timeoutQueue,
 						retransmitQueue, writingQueue, toACK, toPUSH, lzr.ACK)
 				} else {
-					 lzr.SendSyn( input, &ipMeta, timeoutQueue )
+					lzr.SendSyn(input, &ipMeta, timeoutQueue)
 				}
-				ipMeta.FinishProcessing( input )
-            }
+				ipMeta.FinishProcessing(input)
+			}
 			incomingDone.Done()
 			return
-        }(i)
+		}(i)
 	}
 
+	//read from pcap
+	for i := 0; i < options.Workers; i++ {
+		go func(i int) {
+			for input := range pcapIncoming {
+				//fmt.Println("pcap incoming")
+				//fmt.Println(input)
+				inMap, startProcessing := ipMeta.IsStartProcessing(input)
+				//if not in map, return
+				if !inMap {
+					continue
+				}
+				//if another thread is processing, put input back
+				if !startProcessing {
+					pcapIncoming <- input
+					continue
+				}
+				lzr.HandlePcap(options, input, &ipMeta, timeoutQueue,
+					retransmitQueue, writingQueue)
+				ipMeta.FinishProcessing(input)
+				//fmt.Println("finished pcap:")
+				//fmt.Println(input)
+			}
+		}(i)
+	}
 
-    //read from pcap
-    for i := 0; i < options.Workers; i ++ {
-        go func( i int ) {
-            for input := range pcapIncoming {
-						//fmt.Println("pcap incoming")
-						//fmt.Println(input)
-                        inMap, startProcessing := ipMeta.IsStartProcessing( input )
-                        //if not in map, return
-                        if !inMap {
-                            continue
-                        }
-                        //if another thread is processing, put input back
-                        if !startProcessing {
-                            pcapIncoming <- input
-                            continue
-                        }
-				        lzr.HandlePcap(options, input, &ipMeta, timeoutQueue,
-							retransmitQueue, writingQueue )
-                        ipMeta.FinishProcessing( input )
-						//fmt.Println("finished pcap:")
-						//fmt.Println(input)
-            }
-        }(i)
-    }
-
-    //read from timeout
-    for i := 0; i < options.Workers; i ++ {
-		go func( i int ) {
+	//read from timeout
+	for i := 0; i < options.Workers; i++ {
+		go func(i int) {
 
 			for input := range timeoutIncoming {
-                    inMap, startProcessing := ipMeta.IsStartProcessing( input )
-                    //if another thread is processing, put input back
-                    //if not in map, return
-                    if !inMap {
-                        continue
-                    }
-                    if !startProcessing {
-                        timeoutIncoming <- input
-                        continue
-                    }
-		    timeoutDone = false
-                    lzr.HandleTimeout( options, input, &ipMeta, timeoutQueue, retransmitQueue, writingQueue )
-                    ipMeta.FinishProcessing( input )
-		    }
-    }(i)
+				inMap, startProcessing := ipMeta.IsStartProcessing(input)
+				//if another thread is processing, put input back
+				//if not in map, return
+				if !inMap {
+					continue
+				}
+				if !startProcessing {
+					timeoutIncoming <- input
+					continue
+				}
+				lzr.HandleTimeout(options, input, &ipMeta, timeoutQueue, retransmitQueue, writingQueue)
+				ipMeta.FinishProcessing(input)
+			}
+		}(i)
 	}
 
-    //exit gracefully when done
+	//exit gracefully when done
 	incomingDone.Wait()
 
-    for {
-       if done && len(writingQueue) == 0 && !writing && len(timeoutQueue) == 0 {
-				if options.MemProfile != "" {
-					f, err := os.Create(options.MemProfile)
-					if err != nil {
-						log.Fatal(err)
-					}
-					pprof.WriteHeapProfile(f)
-					f.Close()
+	//wait for the cooldown to make sure to receive incoming packets
+	fmt.Fprintf(os.Stderr, "In cooldown for %d seconds to receive SYN ACK packets on the wire\n", options.Cooldown)
+	time.Sleep(time.Duration(options.Cooldown) * time.Second)
+
+	fmt.Fprintln(os.Stderr, "incoming is done, now waiting for handshakes timeout to be expired")
+	wgForHandshakeComplete.Wait()
+	fmt.Fprintln(os.Stderr, "handshakes are completed")
+
+	for {
+		if done && len(writingQueue) == 0 && !writing {
+			if options.MemProfile != "" {
+				f, err := os.Create(options.MemProfile)
+				if err != nil {
+					log.Fatal(err)
 				}
+				pprof.WriteHeapProfile(f)
+				f.Close()
+			}
 			//closing file
 			f.F.Flush()
-			
-	       		startTime := time.Now()
-		        timeoutDone = true
-	       		// 5 second repeated check if any services have called handleTimeout
-		    	for time.Since(startTime) < time.Duration(5)*time.Second {
-				if !(timeoutDone) {
-			    		startTime = time.Now()
-			    		timeoutDone = true
-				}
-		    	}
 			t := time.Now()
 			elapsed := t.Sub(start)
-	       		
-			lzr.Summarize( elapsed )
-            return
-       }
-    }
-
-
+			lzr.Summarize(elapsed)
+			return
+		}
+	}
 
 } //end of main

--- a/commandline_parse.go
+++ b/commandline_parse.go
@@ -15,119 +15,119 @@ limitations under the License.
 */
 
 package lzr
+
 import (
-  "flag"
-  "fmt"
-  "log"
-  "os"
-  "time"
-  "strings"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
 )
 
 var (
-
-	filename				*string
-	sendSYNs				*bool
-	sourceIP				*string
-	device					*string
-	mac						*string
-	debug					*bool
-	haf						*int
-	pushDOnly				*bool
-	forceAllHandshakes		*bool
-	feedZGrab				*bool
-	workers					*int
-	timeout					*int
-	retransmitSec			*int
-	retransmitNum			*int
-	cpuprofile				*string
-	memprofile				*string
-	handshake				*string
-	priorityFingerprint		*string
-	priorityFingerprintArr	[]string
-	handshakeArr			[]string
-	recordOnlyData			*bool
-	dryrun                  *bool
-	rate                    *int
+	filename               *string
+	sendSYNs               *bool
+	sourceIP               *string
+	device                 *string
+	mac                    *string
+	debug                  *bool
+	haf                    *int
+	pushDOnly              *bool
+	forceAllHandshakes     *bool
+	feedZGrab              *bool
+	workers                *int
+	timeout                *int
+	cooldown               *int
+	retransmitSec          *int
+	retransmitNum          *int
+	cpuprofile             *string
+	memprofile             *string
+	handshake              *string
+	priorityFingerprint    *string
+	priorityFingerprintArr []string
+	handshakeArr           []string
+	recordOnlyData         *bool
+	dryrun                 *bool
+	rate                   *int
 )
 
 type options struct {
-
-	Filename			string
-	SendSYNs			bool
-	SourceIP			string
-	Device				string
-	Mac					string
-	Debug				bool
-	Haf					int
-	PushDOnly			bool
-	ForceAllHandshakes	bool
-	FeedZGrab			bool
-	Workers				int
-	Timeout				int
-	RetransmitSec		int
-	RetransmitNum		int
-	CPUProfile			string
-	MemProfile			string
-	Handshakes			[]string
-	PriorityFingerprint	[]string
-	RecordOnlyData		bool
+	Filename            string
+	SendSYNs            bool
+	SourceIP            string
+	Device              string
+	Mac                 string
+	Debug               bool
+	Haf                 int
+	PushDOnly           bool
+	ForceAllHandshakes  bool
+	FeedZGrab           bool
+	Workers             int
+	Timeout             int
+	Cooldown            int
+	RetransmitSec       int
+	RetransmitNum       int
+	CPUProfile          string
+	MemProfile          string
+	Handshakes          []string
+	PriorityFingerprint []string
+	RecordOnlyData      bool
 	Dryrun              bool
 	Rate                int
 }
 
-
 // Basic flag declarations are available for string, integer, and boolean options.
 func init() {
-  fname := "default_"+string(time.Now().Format("20060102150405"))+".json"
-  filename = flag.String("f", fname , "json results output file name, use '-' for standard output")
-  sendSYNs = flag.Bool("sendSYNs", false , "will read input from stdin containing a newline-delimited list of ip:port")
-  sourceIP = flag.String("sourceIP", "" , "source IP to send syn packets with (if using sendSYNs flag)")
-  device = flag.String("sendInterface", "ens8" , "network interface to send packets on")
-  mac = flag.String("gatewayMac", "" , "gateway Mac Address in format xx:xx:xx:xx:xx:xx")
-  debug = flag.Bool("d", false, "debug printing on")
-  haf = flag.Int("haf", 0, "number of random ephemeral probes to send to filter ACKing firewalls")
-  pushDOnly = flag.Bool("pushDataOnly", false, "Don't attach data to ack but rather to push only")
-  forceAllHandshakes = flag.Bool("forceAllHandshakes", false, "Complete all handshakes even if data is returned early on. This also turns off HyperACKtive filtering.")
-  feedZGrab = flag.Bool("feedZGrab", false, "send to zgrab ip and fingerprint")
-  workers = flag.Int("w", 1 , "number of worker threads for each channel")
-  timeout = flag.Int("t", 5, "number of seconds to wait in timeout queue for last retransmission")
-  retransmitSec = flag.Int("rt", 1 , "number of seconds until re-transmitting packet")
-  retransmitNum = flag.Int("rn", 1 , "number of data packets to re-transmit")
-  cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
-  memprofile = flag.String("memprofile", "", "write memory profile to this file")
-  handshake = flag.String("handshakes", "http" , "handshakes to scan with")
-  priorityFingerprint = flag.String("priorityFingerprint", "" , "fingerprint to prioritize when multiple match")
-  recordOnlyData = flag.Bool("onlyDataRecord", false, "record to file only services that send back data")
-  dryrun = flag.Bool("dryrun", false, "will read output from ZMap's 'dryrun' mode (activates sendSYNs by default)")
-  rate = flag.Int("rate", 1, "number of IP:ports piped in per second if using sendSYNs")
+	fname := "default_" + string(time.Now().Format("20060102150405")) + ".json"
+	filename = flag.String("f", fname, "json results output file name, use '-' for standard output")
+	sendSYNs = flag.Bool("sendSYNs", false, "will read input from stdin containing a newline-delimited list of ip:port")
+	sourceIP = flag.String("sourceIP", "", "source IP to send syn packets with (if using sendSYNs flag)")
+	device = flag.String("sendInterface", "ens8", "network interface to send packets on")
+	mac = flag.String("gatewayMac", "", "gateway Mac Address in format xx:xx:xx:xx:xx:xx")
+	debug = flag.Bool("d", false, "debug printing on")
+	haf = flag.Int("haf", 0, "number of random ephemeral probes to send to filter ACKing firewalls")
+	pushDOnly = flag.Bool("pushDataOnly", false, "Don't attach data to ack but rather to push only")
+	forceAllHandshakes = flag.Bool("forceAllHandshakes", false, "Complete all handshakes even if data is returned early on. This also turns off HyperACKtive filtering.")
+	feedZGrab = flag.Bool("feedZGrab", false, "send to zgrab ip and fingerprint")
+	workers = flag.Int("w", 1, "number of worker threads for each channel")
+	timeout = flag.Int("t", 5, "number of seconds to wait in timeout queue for last retransmission")
+	cooldown = flag.Int("c", 8, "number of seconds to wait after processing all the inputs (i.e., after the input channel is closed)")
+	retransmitSec = flag.Int("rt", 1, "number of seconds until re-transmitting packet")
+	retransmitNum = flag.Int("rn", 1, "number of data packets to re-transmit")
+	cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
+	memprofile = flag.String("memprofile", "", "write memory profile to this file")
+	handshake = flag.String("handshakes", "http", "handshakes to scan with")
+	priorityFingerprint = flag.String("priorityFingerprint", "", "fingerprint to prioritize when multiple match")
+	recordOnlyData = flag.Bool("onlyDataRecord", false, "record to file only services that send back data")
+	dryrun = flag.Bool("dryrun", false, "will read output from ZMap's 'dryrun' mode (activates sendSYNs by default)")
+	rate = flag.Int("rate", 1, "number of IP:ports piped in per second if using sendSYNs")
 }
 
-
-func checkAndParse( handshake *string, optHandshakes *[]string ) ( []string, bool ) {
+func checkAndParse(handshake *string, optHandshakes *[]string) ([]string, bool) {
 
 	if *handshake == "" {
 		return nil, true
 	}
 
-	if !strings.Contains( *handshake, ",")	{
+	if !strings.Contains(*handshake, ",") {
 
 		_, ok := GetHandshake(*handshake)
 
 		if !ok {
-			fmt.Fprintln(os.Stderr,"--Handshake not found:", *handshake)
-			return nil,false
+			fmt.Fprintln(os.Stderr, "--Handshake not found:", *handshake)
+			return nil, false
 		}
 
 		(*optHandshakes)[0] = *handshake
 	} else {
 		i := 0
-		for _, h := range strings.Split( *handshake, "," ) {
+		for _, h := range strings.Split(*handshake, ",") {
 
 			_, ok := GetHandshake(h)
 			if !ok {
-				fmt.Fprintln(os.Stderr,"--Handshake not found:", h)
-				return nil,false
+				fmt.Fprintln(os.Stderr, "--Handshake not found:", h)
+				return nil, false
 			}
 
 			(*optHandshakes)[i] = h
@@ -138,43 +138,43 @@ func checkAndParse( handshake *string, optHandshakes *[]string ) ( []string, boo
 
 }
 
-
-func Parse() (*options,bool) {
+func Parse() (*options, bool) {
 
 	flag.Parse()
 	opt := &options{
-		Filename: *filename,
-		SendSYNs: *sendSYNs,
-		Debug: *debug,
-		Device: *device,
-		Mac: *mac,
-		Haf: *haf,
-		FeedZGrab: *feedZGrab,
-		PushDOnly: *pushDOnly,
-		ForceAllHandshakes: *forceAllHandshakes,
-		Workers: *workers,
-		Timeout: *timeout,
-		RetransmitSec: *retransmitSec,
-		RetransmitNum: *retransmitNum,
-		CPUProfile: *cpuprofile,
-		MemProfile: *memprofile,
-		Handshakes: make([]string, strings.Count(*handshake,",")+1),
-		PriorityFingerprint: make([]string, strings.Count(*priorityFingerprint,",")+1),
-		RecordOnlyData: *recordOnlyData,
-		Dryrun: *dryrun,
-		Rate: *rate,
+		Filename:            *filename,
+		SendSYNs:            *sendSYNs,
+		Debug:               *debug,
+		Device:              *device,
+		Mac:                 *mac,
+		Haf:                 *haf,
+		FeedZGrab:           *feedZGrab,
+		PushDOnly:           *pushDOnly,
+		ForceAllHandshakes:  *forceAllHandshakes,
+		Workers:             *workers,
+		Timeout:             *timeout,
+		Cooldown:            *cooldown,
+		RetransmitSec:       *retransmitSec,
+		RetransmitNum:       *retransmitNum,
+		CPUProfile:          *cpuprofile,
+		MemProfile:          *memprofile,
+		Handshakes:          make([]string, strings.Count(*handshake, ",")+1),
+		PriorityFingerprint: make([]string, strings.Count(*priorityFingerprint, ",")+1),
+		RecordOnlyData:      *recordOnlyData,
+		Dryrun:              *dryrun,
+		Rate:                *rate,
 	}
 
 	if *rate <= 0 {
 		log.Fatalf("Invalid rate: %d. Must be a positive integer.", *rate)
 	}
 	success := false
-	handshakeArr, success = checkAndParse( handshake, &(opt.Handshakes) )
+	handshakeArr, success = checkAndParse(handshake, &(opt.Handshakes))
 	if !success {
 		return nil, false
 	}
 
-	priorityFingerprintArr, success = checkAndParse( priorityFingerprint, &(opt.PriorityFingerprint) )
+	priorityFingerprintArr, success = checkAndParse(priorityFingerprint, &(opt.PriorityFingerprint))
 	if !success {
 		return nil, false
 	}
@@ -183,57 +183,58 @@ func Parse() (*options,bool) {
 		*haf = 0
 	}
 
-	fmt.Fprintln(os.Stderr,"++Writing results to file:", *filename)
-	fmt.Fprintln(os.Stderr,"++Handshakes:", *handshake)
+	fmt.Fprintln(os.Stderr, "++Writing results to file:", *filename)
+	fmt.Fprintln(os.Stderr, "++Handshakes:", *handshake)
 	if *dryrun {
 		fmt.Fprintln(os.Stderr, "++Reading from dryrun")
 		*sendSYNs = true
 	}
 	if *sendSYNs {
-		fmt.Fprintln(os.Stderr,"++Sending SYNs at a rate of: ", *rate)
+		fmt.Fprintln(os.Stderr, "++Sending SYNs at a rate of: ", *rate)
 	}
 	if *sourceIP != "" {
-		fmt.Fprintln(os.Stderr,"++Using SourceIP:", *sourceIP)
+		fmt.Fprintln(os.Stderr, "++Using SourceIP:", *sourceIP)
 	}
 	if *device != "ens8" {
-		fmt.Fprintln(os.Stderr,"++Using Sending Interface:", *device)
+		fmt.Fprintln(os.Stderr, "++Using Sending Interface:", *device)
 	}
 	if *mac != "" {
-		fmt.Fprintln(os.Stderr,"++Using Gateway Mac:", *mac)
+		fmt.Fprintln(os.Stderr, "++Using Gateway Mac:", *mac)
 	}
 	if *priorityFingerprint != "" {
-		fmt.Fprintln(os.Stderr,"++Prioritizing Fingerprints:", *priorityFingerprint)
+		fmt.Fprintln(os.Stderr, "++Prioritizing Fingerprints:", *priorityFingerprint)
 	}
 	if *memprofile != "" {
-		fmt.Fprintln(os.Stderr,"++Writing memprofile to file:", *memprofile)
+		fmt.Fprintln(os.Stderr, "++Writing memprofile to file:", *memprofile)
 	}
 	if *cpuprofile != "" {
-		fmt.Fprintln(os.Stderr,"++Writing cpuprofile to file:", *cpuprofile)
+		fmt.Fprintln(os.Stderr, "++Writing cpuprofile to file:", *cpuprofile)
 	}
 	if *debug {
-		fmt.Fprintln(os.Stderr,"++Debug turned on")
+		fmt.Fprintln(os.Stderr, "++Debug turned on")
 	}
 	if *haf > 0 {
-		fmt.Fprintln(os.Stderr,"++Sending ",*haf, " number of filtering packets")
+		fmt.Fprintln(os.Stderr, "++Sending ", *haf, " number of filtering packets")
 	}
 	if *feedZGrab {
-		fmt.Fprintln(os.Stderr,"++Feeding ZGrab with fingerprints")
+		fmt.Fprintln(os.Stderr, "++Feeding ZGrab with fingerprints")
 	}
 	if *pushDOnly {
-		fmt.Fprintln(os.Stderr,"++Sending Data only with Push Flag (not in ack)")
+		fmt.Fprintln(os.Stderr, "++Sending Data only with Push Flag (not in ack)")
 	}
 	if *forceAllHandshakes {
-		fmt.Fprintln(os.Stderr,"++Force completing all handshakes")
+		fmt.Fprintln(os.Stderr, "++Force completing all handshakes")
 	}
 	if *recordOnlyData {
-		fmt.Fprintln(os.Stderr,"++Recording to file only services that return data")
+		fmt.Fprintln(os.Stderr, "++Recording to file only services that return data")
 	}
-	fmt.Fprintln(os.Stderr,"++Worker threads:", *workers)
-	fmt.Fprintln(os.Stderr,"++Timeout Interval (s):", *timeout)
-	fmt.Fprintln(os.Stderr,"++Retransmit Interval (s):", *retransmitSec)
-	fmt.Fprintln(os.Stderr,"++Number of Retransmitions:", *retransmitNum)
+	fmt.Fprintln(os.Stderr, "++Worker threads:", *workers)
+	fmt.Fprintln(os.Stderr, "++Timeout Interval (s):", *timeout)
+	fmt.Fprintln(os.Stderr, "++Cooldown after completing (s):", *cooldown)
+	fmt.Fprintln(os.Stderr, "++Retransmit Interval (s):", *retransmitSec)
+	fmt.Fprintln(os.Stderr, "++Number of Retransmitions:", *retransmitNum)
 	//fmt.Fprintln(os.Stderr,"port:", *port)
-	return opt,true
+	return opt, true
 }
 
 func DebugOn() bool {
@@ -269,7 +270,7 @@ func getSourceIP() string {
 }
 
 func getDevice() string {
-    return *device
+	return *device
 }
 
 func getHostMacAddr() string {
@@ -284,7 +285,7 @@ func ForceAllHandshakes() bool {
 	return *forceAllHandshakes
 }
 
-func GetAllHandshakes()  []string {
+func GetAllHandshakes() []string {
 
 	if priorityFingerprintArr != nil {
 		return priorityFingerprintArr
@@ -293,6 +294,5 @@ func GetAllHandshakes()  []string {
 }
 
 func NumHandshakes() int {
-    return len(handshakeArr)
+	return len(handshakeArr)
 }
-


### PR DESCRIPTION
his commit addresses the issue of premature process termination, where the process was exiting without waiting for all responses to be received.

As also mentioned in [issue #23](https://github.com/stanford-esrg/lzr/issues/23), this update introduces a cooldown option -c (similar to what is done in ZMap) to allow time for in-flight packets to arrive (https://github.com/stanford-esrg/lzr/compare/master...merterdemir:lzr:master#diff-74e55414966850563a5ea05f18bdea215a1a6e43745456e3c779864773e84910R189). It also ensures that all expected handshakes are given time to reach their timeout before termination (https://github.com/stanford-esrg/lzr/compare/master...merterdemir:lzr:master#diff-74e55414966850563a5ea05f18bdea215a1a6e43745456e3c779864773e84910R192).

The cooldown option defaults to 8 seconds but can be customized.

Additionally, we modified the Concurrent Map structure to return both the count and the update (https://github.com/stanford-esrg/lzr/compare/master...merterdemir:lzr:master#diff-f177b1490d4ed6c7fd5eef27ad72c24fe7e6ef276246868e6c799a91c21a6fd4R146). This enhancement (update  flag is already included in the latest LZR commit) helps identify when elements are updated even if their count remains the same. These values are used to avoid infinite waiting loops during the response collection phase. This also resulted in reverting the recent changes made to the export summary code block and removing the timeout queue length checks (to simplify that code block) -- https://github.com/stanford-esrg/lzr/compare/master...merterdemir:lzr:master#diff-f177b1490d4ed6c7fd5eef27ad72c24fe7e6ef276246868e6c799a91c21a6fd4R146 --.

These changes were made through the collective efforts of @mratmeyer, @GQW19, and myself. Please let us know if something looks broken or there is anything we can help explaining more.

Note: I am sorry for all the other changes appear due to formatting :smiling_face_with_tear: 
