### PR TITLE
Add IPv6 Support

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -41,7 +41,7 @@ func LZRMain() {
 	lzr.InitParams()
 
 	writingQueue := lzr.ConstructWritingQueue(options.Workers)
-	pcapIncoming := lzr.ConstructPcapRoutine(options.Workers)
+	pcapIncoming := lzr.ConstructPcapRoutine(options.Workers, options.IPv6Enabled)
 	timeoutQueue := lzr.ConstructTimeoutQueue(options.Workers)
 	retransmitQueue := lzr.ConstructRetransmitQueue(options.Workers)
 	timeoutIncoming := lzr.PollTimeoutRoutine(

--- a/commandline_parse.go
+++ b/commandline_parse.go
@@ -50,6 +50,7 @@ var (
 	recordOnlyData         *bool
 	dryrun                 *bool
 	rate                   *int
+	ipv6Enabled            *bool
 )
 
 type options struct {
@@ -75,6 +76,7 @@ type options struct {
 	RecordOnlyData      bool
 	Dryrun              bool
 	Rate                int
+	IPv6Enabled         bool
 }
 
 // Basic flag declarations are available for string, integer, and boolean options.
@@ -102,6 +104,7 @@ func init() {
 	recordOnlyData = flag.Bool("onlyDataRecord", false, "record to file only services that send back data")
 	dryrun = flag.Bool("dryrun", false, "will read output from ZMap's 'dryrun' mode (activates sendSYNs by default)")
 	rate = flag.Int("rate", 1, "number of IP:ports piped in per second if using sendSYNs")
+	ipv6Enabled = flag.Bool("ipv6Enabled", false, "Enable IPv6 support")
 }
 
 func checkAndParse(handshake *string, optHandshakes *[]string) ([]string, bool) {
@@ -163,6 +166,7 @@ func Parse() (*options, bool) {
 		RecordOnlyData:      *recordOnlyData,
 		Dryrun:              *dryrun,
 		Rate:                *rate,
+		IPv6Enabled:         *ipv6Enabled,
 	}
 
 	if *rate <= 0 {
@@ -239,6 +243,10 @@ func Parse() (*options, bool) {
 
 func DebugOn() bool {
 	return *debug
+}
+
+func IPv6Enabled() bool {
+	return *ipv6Enabled
 }
 
 func RecordOnlyData() bool {

--- a/construct_main_routines.go
+++ b/construct_main_routines.go
@@ -139,7 +139,7 @@ func ConstructIncomingRoutine( workers int ) chan *packet_metadata {
     return incoming
 }
 
-func ConstructPcapRoutine( workers int ) chan *packet_metadata {
+func ConstructPcapRoutine( workers int, useIPv6 bool ) chan *packet_metadata {
 
 	//routine to read in from pcap
 	pcapIncoming := make(chan *packet_metadata, QUEUE_SIZE)
@@ -151,7 +151,11 @@ func ConstructPcapRoutine( workers int ) chan *packet_metadata {
 		log.Fatal(err)
 	}
 	//set to filter out zmap syn packets (just syn) 
-	err := handle.SetBPFFilter("tcp[tcpflags] != tcp-syn")
+	filter := "tcp[tcpflags] != tcp-syn"
+	if useIPv6 == true {
+		filter = "(ip6 proto 6 && (ip6[53] & 4 != 0 || ip6[53] != 2))"
+	}
+	err := handle.SetBPFFilter(filter)
 	if err != nil {
         panic(err)
 		log.Fatal(err)

--- a/handshakes/http/handshake.go
+++ b/handshakes/http/handshake.go
@@ -1,9 +1,10 @@
 package http
 
 import (
-    "net/http"
-    "net/http/httputil"
+	"net/http"
+	"net/http/httputil"
 	"strings"
+
 	"github.com/stanford-esrg/lzr"
 )
 
@@ -11,24 +12,28 @@ import (
 type HandshakeMod struct {
 }
 
-func (h *HandshakeMod) GetData( dst string ) []byte {
+func (h *HandshakeMod) GetData(dst string) []byte {
 
-        req, _ := http.NewRequest("GET","/",nil)
-        req.Host =  dst
-        req.Header.Add("Host",dst)
-        req.Header.Set("User-Agent","Mozilla/5.0 zgrab/0.x")
-        req.Header.Set("Accept","*/*")
-        req.Header.Set("Accept-Encoding","gzip")
-        data, _ := httputil.DumpRequest(req, false)
-    return data
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Host = dst
+	if lzr.IPv6Enabled() {
+		req.Header.Add("Host", "["+dst+"]")
+	} else {
+		req.Header.Add("Host", dst)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 zgrab/0.x")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Encoding", "gzip")
+	data, _ := httputil.DumpRequest(req, false)
+	return data
 }
 
-func (h *HandshakeMod) Verify( data string ) string {
+func (h *HandshakeMod) Verify(data string) string {
 
-	if !strings.Contains( data, "HTTPS" ) &&
-		(strings.Contains( data, "HTTP" ) || strings.Contains( data, "html" ) ||
-		strings.Contains( data, "HTML") || strings.Contains( data, "<h1>" )) {
-         return "http"
+	if !strings.Contains(data, "HTTPS") &&
+		(strings.Contains(data, "HTTP") || strings.Contains(data, "html") ||
+			strings.Contains(data, "HTML") || strings.Contains(data, "<h1>")) {
+		return "http"
 	}
 	return ""
 
@@ -36,6 +41,5 @@ func (h *HandshakeMod) Verify( data string ) string {
 
 func RegisterHandshake() {
 	var h HandshakeMod
-	lzr.AddHandshake( "http", &h )
+	lzr.AddHandshake("http", &h)
 }
-

--- a/handshakes/ipp/handshake.go
+++ b/handshakes/ipp/handshake.go
@@ -1,9 +1,10 @@
 package ipp
 
 import (
-    "net/http"
-    "net/http/httputil"
+	"net/http"
+	"net/http/httputil"
 	"strings"
+
 	"github.com/stanford-esrg/lzr"
 )
 
@@ -11,26 +12,30 @@ import (
 type HandshakeMod struct {
 }
 
-func (h *HandshakeMod) GetData( dst string ) []byte {
+func (h *HandshakeMod) GetData(dst string) []byte {
 
-        req, _ := http.NewRequest("POST","/ipp",nil)
-        req.Host =  dst
-        req.Header.Add("Host",dst)
-        req.Header.Set("User-Agent","Mozilla/5.0 zgrab/0.x")
-        req.Header.Set("Accept","*/*")
-        req.Header.Set("Content-Type","application/ipp")
-        req.Header.Set("Accept-Encoding","gzip")
-        data, _ := httputil.DumpRequest(req, false)
-    return data
+	req, _ := http.NewRequest("POST", "/ipp", nil)
+	req.Host = dst
+	if lzr.IPv6Enabled() {
+		req.Header.Add("Host", "["+dst+"]")
+	} else {
+		req.Header.Add("Host", dst)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 zgrab/0.x")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Content-Type", "application/ipp")
+	req.Header.Set("Accept-Encoding", "gzip")
+	data, _ := httputil.DumpRequest(req, false)
+	return data
 }
 
-func (h *HandshakeMod) Verify( data string ) string {
+func (h *HandshakeMod) Verify(data string) string {
 
-    if strings.Contains( data, "ipp" ) &&
-		 strings.Contains( data, "200 OK" ) {
+	if strings.Contains(data, "ipp") &&
+		strings.Contains(data, "200 OK") {
 
-		 if strings.Contains( data, "attributes-charset" ) ||
-			strings.Contains( data, "print" ){
+		if strings.Contains(data, "attributes-charset") ||
+			strings.Contains(data, "print") {
 			return "ipp"
 		}
 	}
@@ -40,6 +45,5 @@ func (h *HandshakeMod) Verify( data string ) string {
 
 func RegisterHandshake() {
 	var h HandshakeMod
-	lzr.AddHandshake( "ipp", &h )
+	lzr.AddHandshake("ipp", &h)
 }
-


### PR DESCRIPTION
This PR adds a few changes to make LZR compatible with IPv6:

- New `ipv6Enabled` flag, false by default which enables support for IPv6
- Updates BPF filter in IPv6 mode
- Adds brackets around host header to be compatible with IPv6
- Explode IPv6 IPs

These changes were made by @merterdemir, @GQW19, and myself.