### PR TITLE
LZR bugFixes, handshake edits, and additional IPv6 updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ $ cd $GOPATH/src/github.com/stanford-esrg/lzr
 
 LZR intercepts connections which ZMap opens; in order to ensure that the kernel does not interfere with LZR, LZR requires a source-ip to be specified for which the kernel drops all RSTs for traffic targeted to the source-ip. The chosen source-ip&mdash;which both ZMap and LZR will use&mdash;should be passed in as a parameter to make, so the appropriate iptables rule can be set.
 ```
-$ make all source-ip=256.256.256.256/32
+$ make all source-ip=256.256.256.256
+```
+
+It works the same for the IPv6 as the script determines whether the source IP is a IPv4 address or not by checking the ``.`` character within the source IP string. If IPv6, it uses ``ip6tables`` rather than ``iptables``.
+```
+$ make all source-ip=ffff:ffff:ffff:ffff::ffff
 ```
 
 ## Usage
@@ -56,6 +61,9 @@ To scan a sample of IP:Port from ZMap's dryrun option (i.e., ZMap still determin
 sudo zmap --target-port=9002 -O - --source-ip=$source-ip --dryrun | sudo ./lzr --handshakes http -dryrun -sourceIP $source-ip -gatewayMac $gateway
 ```
 
+### IPv6
+For IPv6, you could just set the ``--ipv6`` flag, and the LZR will switch to IPv6 mode.
+
 ## Flags
 ```
 $ ./lzr --help
@@ -76,6 +84,8 @@ Usage of ./lzr:
     	number of random ephemeral probes to send to filter ACKing firewalls
   -handshakes string
     	handshakes to scan with (default "http")
+  -ipv6
+		Enable IPv6 support
   -memprofile string
     	write memory profile to this file
   -priorityFingerprint string

--- a/construct_main_routines.go
+++ b/construct_main_routines.go
@@ -137,7 +137,7 @@ func ConstructIncomingRoutine(workers int) chan *packet_metadata {
 	return incoming
 }
 
-func ConstructPcapRoutine(workers int, useIPv6 bool) chan *packet_metadata {
+func ConstructPcapRoutine(workers int) chan *packet_metadata {
 
 	//routine to read in from pcap
 	pcapIncoming := make(chan *packet_metadata, QUEUE_SIZE)

--- a/construct_responses.go
+++ b/construct_responses.go
@@ -205,7 +205,6 @@ func constructData(handshake Handshake, p *packet_metadata, ack bool, push bool)
 			log.Fatal(err)
 		}
 	}
-
 	outPacket := buffer.Bytes()
 	return outPacket, data
 

--- a/handle_expired.go
+++ b/handle_expired.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,81 +15,75 @@ limitations under the License.
 */
 package lzr
 
-import (
-	//"fmt"
-)
+// import (
+// 	"fmt"
+// )
 
-func handleExpired( opts *options, packet * packet_metadata, ipMeta * pState,
-	timeoutQueue chan *packet_metadata, writingQueue chan *packet_metadata ) {
-
+func handleExpired(opts *options, packet *packet_metadata, ipMeta *pState,
+	timeoutQueue chan *packet_metadata, writingQueue chan *packet_metadata) {
 
 	// first close the existing connection unless
 	// its already been terminated
-	if !( packet.RST && !packet.ACK ) && !(packet.ExpectedRToLZR == SYN_ACK) {
+	if !(packet.RST && !packet.ACK) && !(packet.ExpectedRToLZR == SYN_ACK) {
 
-		rst := constructRST( packet )
-		_ = handle.WritePacketData( rst )
+		rst := constructRST(packet)
+		_ = handle.WritePacketData(rst)
 
 	}
 
 	//grab which handshake
-	handshakeNum := ipMeta.getHandshake( packet )
+	handshakeNum := ipMeta.getHandshake(packet)
 
 	//if we are all not trying anymore handshakes, so sad.
 	//because:
 	//1. it was a HAF packet to begin with
 	//2. we have run out of handshakes
-	//3. doesnt synack 
+	//3. doesnt synack
 	//if ( packet.ExpectedRToLZR == SYN_ACK ||
-	if ( packet.HyperACKtive  || (handshakeNum >= (len( opts.Handshakes ) - 1)) ||
-		(packet.ExpectedRToLZR == SYN_ACK  && !ForceAllHandshakes() )){
-
-		packet.syncHandshakeNum( handshakeNum )
+	if packet.HyperACKtive || (handshakeNum >= (len(opts.Handshakes) - 1)) ||
+		(packet.ExpectedRToLZR == SYN_ACK && !ForceAllHandshakes()) {
+		packet.syncHandshakeNum(handshakeNum)
 
 		//document failure if its a handshake response that hasnt succeeded before
-		if !packet.HyperACKtive && !( ForceAllHandshakes() && ipMeta.getData( packet ) && !(packet.hasData())) {
-
+		if !packet.HyperACKtive && !(ForceAllHandshakes() && ipMeta.getData(packet) && !(packet.hasData())) {
 			if !(!(packet.hasData()) && RecordOnlyData()) {
 				writingQueue <- packet
 			} else {
 				addToSummary(packet)
 			}
-
 		}
 
 		//remove from state, we are done now
-		packet = ipMeta.remove( packet )
+		packet = ipMeta.remove(packet)
 		if HyperACKtiveFiltering() {
-			packet.HyperACKtive = true
-			packet = ipMeta.remove( packet )
+			//packet.HyperACKtive = true
+			packet = ipMeta.remove(packet)
 		}
 	} else { // lets try another handshake
-
-
 		//record all succesful fingerprints if forcing all handshakes
 		if ForceAllHandshakes() && packet.hasData() {
-			packet.syncHandshakeNum( handshakeNum )
+			packet.syncHandshakeNum(handshakeNum)
 			writingQueue <- packet
 		}
 
 		packet.updatePacketFlow()
-		ipMeta.incHandshake( packet )
-		SendSyn( packet, ipMeta, timeoutQueue )
+		ipMeta.incHandshake(packet)
+		SendSyn(packet, ipMeta, timeoutQueue)
 
 		//lets also filter for HyperACKtive hosts
-		if ( handshakeNum == 0 &&  HyperACKtiveFiltering() ) {
+		if handshakeNum == 0 && HyperACKtiveFiltering() {
 			for i := 0; i < getNumFilters(); i++ {
-				highPortPacket := createFilterPacket( packet )
-				SendSyn( highPortPacket, ipMeta, timeoutQueue )
-				ipMeta.incHandshake( highPortPacket )
-				ipMeta.setHyperACKtiveStatus( highPortPacket )
+				highPortPacket := createFilterPacket(packet)
+				// log.Printf("++++ SENDING HAF PACKET ON PORT: %+v\n", highPortPacket)
+				SendSyn(highPortPacket, ipMeta, timeoutQueue)
+				ipMeta.incHandshake(highPortPacket)
+				ipMeta.setHyperACKtiveStatus(highPortPacket)
 
-				ipMeta.setParentSport( highPortPacket, packet.Sport )
-				ipMeta.FinishProcessing( highPortPacket )
+				ipMeta.setParentSport(highPortPacket, packet.Sport)
+				ipMeta.FinishProcessing(highPortPacket)
 			}
 		}
 
 	}
 
 }
-

--- a/handshakes/bgp.go
+++ b/handshakes/bgp.go
@@ -1,0 +1,7 @@
+package handshakes
+
+import "github.com/stanford-esrg/lzr/handshakes/bgp"
+
+func init() {
+	bgp.RegisterHandshake()
+}

--- a/handshakes/bgp/handshake.go
+++ b/handshakes/bgp/handshake.go
@@ -1,0 +1,38 @@
+package bgp
+
+import (
+	"github.com/stanford-esrg/lzr"
+)
+
+// Handshake implements the lzr.Handshake interface
+type HandshakeMod struct {
+}
+
+// Send Garbage Data to prompt a notification message
+func (h *HandshakeMod) GetData(dst string) []byte {
+	data := []byte("\n\n")
+	return data
+}
+
+func (h *HandshakeMod) Verify(data string) string {
+	if len(data) < 16 {
+		return ""
+	}
+
+	correctBGP := true
+	for i := 0; i < 16 && correctBGP; i++ {
+		if data[i] != byte(0xff) {
+			correctBGP = false
+		}
+	}
+
+	if correctBGP == true {
+		return "bgp"
+	}
+	return ""
+}
+
+func RegisterHandshake() {
+	var h HandshakeMod
+	lzr.AddHandshake("bgp", &h)
+}

--- a/handshakes/ftp/handshake.go
+++ b/handshakes/ftp/handshake.go
@@ -30,7 +30,11 @@ func (h *HandshakeMod) Verify( data string ) string {
 		strings.Contains( data[0:3], "530" ) ||
 		strings.Contains( data[0:3], "550" ) ||
 		strings.Contains( data[0:3], "230" ) {
-		return "ftp"
+		if !strings.Contains( ToLower(data), "smtp" ) && !strings.Contains( ToLower(data), "ehlo" ) {
+			// We need an additional check against SMTP because it uses the same status codes.
+			return "ftp"
+		}
+		return ""
 	}
 
     return ""

--- a/handshakes/http/handshake.go
+++ b/handshakes/http/handshake.go
@@ -21,7 +21,7 @@ func (h *HandshakeMod) GetData(dst string) []byte {
 	} else {
 		req.Header.Add("Host", dst)
 	}
-	req.Header.Set("User-Agent", "Mozilla/5.0 zgrab/0.x")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.3")
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Accept-Encoding", "gzip")
 	data, _ := httputil.DumpRequest(req, false)

--- a/handshakes/imap/handshake.go
+++ b/handshakes/imap/handshake.go
@@ -19,7 +19,13 @@ func (h *HandshakeMod) GetData( dst string ) []byte {
 func (h *HandshakeMod) Verify( data string ) string {
 	if data == "" || !isASCII(data) {
 		return ""
-	} else if strings.Contains( ToLower(data), "imap" ) {
+	} else if strings.HasPrefix(data, "+OK") || strings.HasPrefix(data, "-ERR") {
+		// Some POP3 servers include in their banner that they have IMAP capability on another port
+		// so it is necessary to not label these as IMAP
+		return ""
+	} else if strings.HasPrefix(data, "* OK") || strings.HasPrefix(data, "* BYE") || strings.HasPrefix(data, "* PREAUTH") {
+		return "imap"
+	} else if strings.Contains( ToLower(data), "imap" ) || strings.Contains( data, "* OK") {
 		return "imap"
 	}
     return ""

--- a/handshakes/ipp/handshake.go
+++ b/handshakes/ipp/handshake.go
@@ -21,7 +21,7 @@ func (h *HandshakeMod) GetData(dst string) []byte {
 	} else {
 		req.Header.Add("Host", dst)
 	}
-	req.Header.Set("User-Agent", "Mozilla/5.0 zgrab/0.x")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.3")
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Content-Type", "application/ipp")
 	req.Header.Set("Accept-Encoding", "gzip")

--- a/handshakes/pop3/handshake.go
+++ b/handshakes/pop3/handshake.go
@@ -18,8 +18,14 @@ func (h *HandshakeMod) GetData( dst string ) []byte {
 func (h *HandshakeMod) Verify( data string ) string {
     if data == "" || !isASCII(data) {
         return ""
+    } else if strings.HasPrefix(data, "* OK") || strings.HasPrefix(data, "* BYE") || strings.HasPrefix(data, "* PREAUTH") {
+        // Some IMAP servers include in their banner that they have POP3 capability on another port
+		// so it is necessary to not label these as POP3
+		return ""
+    } else if strings.HasPrefix(data, "+OK") || strings.HasPrefix(data, "-ERR") {
+        return "pop3"
     } else if strings.Contains( ToLower(data), "pop3" ) ||
-		strings.Contains( data, "+OK") || strings.Contains( data, "* OK") {
+		strings.Contains( data, "+OK") {
         return "pop3"
     }
     return ""

--- a/handshakes/smtp/handshake.go
+++ b/handshakes/smtp/handshake.go
@@ -21,6 +21,20 @@ func (h *HandshakeMod) Verify( data string ) string {
 	if strings.Contains( dl, "smtp" ) || strings.Contains( dl, "ehlo" ) {
          return "smtp"
 	}
+	if len(data) < 4 {
+		return ""
+	}
+    if strings.Contains( data[0:3], "220" ) ||
+		strings.Contains( data[0:3], "421" ) ||
+		strings.Contains( data[0:3], "530" ) ||
+		strings.Contains( data[0:3], "550" ) ||
+		strings.Contains( data[0:3], "230" ) {
+		if !strings.Contains( ToLower(data), "ftp" ) {
+			// We need an additional check against FTP because it uses the same status codes.
+			return "smtp"
+		}
+		return ""
+	}
     return ""
 }
 

--- a/output.go
+++ b/output.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"time"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -94,7 +95,7 @@ func ( f *output_file ) Record( packet *packet_metadata, handshakes []string ) {
 
 	if FeedZGrab() {
 		if packet.Fingerprint != "" {
-			fmt.Println( packet.Saddr + ", ," + packet.Fingerprint )
+			fmt.Println(packet.Saddr + ",," + packet.Fingerprint + "," + strconv.Itoa(packet.Sport))
 		}
 	}
 

--- a/packet.go
+++ b/packet.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	//"fmt"
 	//"os"
 )
 
@@ -131,12 +132,10 @@ func ReadLayers(ip *layers.IPv4, tcp *layers.TCP, eth *layers.Ethernet) *packet_
 		Processing:   true,
 		HandshakeNum: 0,
 	}
-
 	if IPv6Enabled() {
 		packet.Saddr = Explode(ip.SrcIP)
 		packet.Daddr = Explode(ip.DstIP)
 	}
-
 	return packet
 }
 
@@ -202,7 +201,9 @@ func convertFromInputListToPacket(input string) *packet_metadata {
 	t := time.Now()
 	//expecting ip, port
 	input = strings.TrimSuffix(input, "\n")
+	// IPV6 ADDITIONS
 	s := strings.Split(input, ";")
+	// END IPV6 ADDITIONS
 	if len(s) != 2 {
 		panic("Error parsing input list")
 	}

--- a/packet.go
+++ b/packet.go
@@ -201,9 +201,7 @@ func convertFromInputListToPacket(input string) *packet_metadata {
 	t := time.Now()
 	//expecting ip, port
 	input = strings.TrimSuffix(input, "\n")
-	// IPV6 ADDITIONS
 	s := strings.Split(input, ";")
-	// END IPV6 ADDITIONS
 	if len(s) != 2 {
 		panic("Error parsing input list")
 	}

--- a/stateMap.go
+++ b/stateMap.go
@@ -32,7 +32,7 @@ func ConstructPacketStateMap( opts *options ) pState {
 
 
 func constructKey( packet *packet_metadata ) string {
-	return packet.Saddr + ":" + strconv.Itoa(packet.Sport) + ":" + strconv.Itoa(packet.Dport)
+	return packet.Saddr + ":" + strconv.Itoa(packet.Sport) //+ ":" + strconv.Itoa(packet.Dport)
 }
 
 func constructParentKey( packet *packet_metadata, parentSport int ) string {
@@ -45,6 +45,10 @@ func (ipMeta * pState) metaContains( p * packet_metadata ) bool {
 	pKey := constructKey(p)
 	return ipMeta.Has(pKey)
 
+}
+
+func (ipMeta * pState) MetaContains( p * packet_metadata ) bool {
+	return ipMeta.metaContains(p)
 }
 
 


### PR DESCRIPTION
# LZR bugFixes, handshake edits, and additional IPv6 updates

## Changes

### BugFixes:
-Remove source port from ```ipMeta``` key (because source port is incremented per handshake, so it is not the same across handshakes). 
-Corrected bug where all non-fingerprinted packets were listed as HAF packets. 
-Corrected bug where sometimes handshake would be incremented one too many times (this is rare, but will cause LZR to crash when it appears; to fix it we add a check on the handshake number when processing pcap packets to ensure we haven't already exhausted all handshakes and returned the packet). 

### Features:
- Return port in ZGrab label (since LZR can take multiple ports).
- Add BGP Module:
  - Module: We do not currently send any meaningful BGP data, only sending newlines and hoping for a BGP error, to ensure we do not in any way interfere with BGP systems. BGP is server first, so typically it can be fingerprinted without needing to send packets directly (and a fingerprint was added).
  -  Fingerprint Hierarchy: Prioritize BGP over telnet (BGP's fingerprint is much more specific, and BGP packets will also match Telnet's more general fingerprint).
- Maintain order of handshake fingerprints checked against returned data in the output processor, to ensure only one variation of each pair exists (i.e. 'ftp-smtp' is the same as 'smtp-ftp', so only one of those two labels should exist and not both to assist with post-processing).
- Added HafThreshold: number of random ports to try when running haf detection. 

### Functionality Changes:
- Prevent input from creating multiple copies of same ip/port pair if duplicate inputs are detected. 
- No longer include intial response in HAF threshold.
- IPv6: Small updates to how IPv6 flags are passed across LZR.
- Protocol Fingerprints:
  - FTP: Update FTP fingerprinting to disregard identifiable SMTP packets (since SMTP uses the same status codes). 
  - SMTP: Update SMTP fingerprinting to look for status code replies that can't be identified as FTP (this usually returns a small number of smtp-ftp label pairs when a status code exists but the banner does not indicate whether the host is SMTP or FTP; however, these hosts should be labeled as such, since it is impossible to tell without follow up packets which protocol they are running). 
  - IMAP: Prevent POP3 fingerprinted hosts (with the POP3 ```+OK``` or ```-ERR``` banner) from being labelled as IMAP. This is necessary because many mailservers run both IMAP and POP3 on their respective ports, and their banners describe running both protocols (meaning the strings IMAP and POP3 appear in each banner). The servers can be differentiated however, because they use different protocol-specific prefixes (```+OK``` for POP3 vs. ```* OK``` for IMAP). 
  - POP3: Similarly, prevent mislabeling of IMAP servers as POP3. 

### Other:
- Update README to reflect IPv6 support.
- Various spacing/small formatting changes. 

## Notes/Caveats
- Fingerprints:
  - SMTP-FTP: In the future it may make sense to include more nuanced domain parsing of the server names in smtp-ftp servers. This may give us insight into what protocol the server is running when it is impossible to determine between smtp and ftp. 


## Evaluation: 
This PR has been evaluated using ZMap scans across 1M and 50M samples of the IPv4 internet (and similar samples of publicly accessible IPv6 addresses). 

## Acknowledgements
- Many thanks to @merterdemir for assisting with this PR (especially surrounding HAF detection functionality and additional IPv6 updates). 
- Also thanks to @LizIzhikevich for guidance on these changes and how LZR operates!

